### PR TITLE
Handle semantic version correctly

### DIFF
--- a/lib/exrm_rpm/exrm_rpm.ex
+++ b/lib/exrm_rpm/exrm_rpm.ex
@@ -178,7 +178,7 @@ defmodule ReleaseManager.Plugin.Rpm do
   end
 
   def rpm_file_name(name, version, arch, match \\ false),
-    do: "#{name}-#{version |> normalize_version}-0.#{if match, do: "*", else: ""}#{arch}.rpm"
+    do: "#{name}-#{version |> normalize_version}-#{version |> build_number}.#{if match, do: "*", else: ""}#{arch}.rpm"
 
   def get_config_item(config, item, default) do
     app    = String.to_atom config.name

--- a/lib/exrm_rpm/exrm_rpm.ex
+++ b/lib/exrm_rpm/exrm_rpm.ex
@@ -1,5 +1,6 @@
 defmodule ReleaseManager.Plugin.Rpm do
   use ReleaseManager.Plugin
+  import ReleaseManager.Plugin.Rpm.NormalizeVersion
   alias ReleaseManager.Config
 
   @_SPEC                "spec"
@@ -114,25 +115,6 @@ defmodule ReleaseManager.Plugin.Rpm do
 
     File.write!(dest, contents)
     config
-  end
-
-  defp normalize_version(version) when is_binary(version) do
-    version |> String.split([".", "-"]) |> normalize_version |> Enum.join(".")
-  end
-  defp normalize_version(v = [_maj, _min, _patch]) do
-    v
-  end
-  defp normalize_version(v = [maj, _min, _patch, _pre]) when is_binary(maj) do
-    normalize_version(v |> Enum.map(fn(segment) -> Regex.replace(~r/[^0-9]+/, segment, "") |> String.to_integer end))
-  end
-  defp normalize_version([maj, 0, 0, pre]) when maj > 0 do
-    [maj - 1, 99, 99, 99, pre]
-  end
-  defp normalize_version([maj, min, 0, pre]) when min > 0 do
-    [maj, min - 1, 99, 99, pre]
-  end
-  defp normalize_version([maj, min, patch, pre]) when patch > 0 do
-    [maj, min, patch - 1, 99, pre]
   end
 
   defp copy_extra_sources(config) do

--- a/lib/exrm_rpm/normalize_version.ex
+++ b/lib/exrm_rpm/normalize_version.ex
@@ -1,0 +1,25 @@
+defmodule ReleaseManager.Plugin.Rpm.NormalizeVersion do
+  def normalize_version(version) when is_binary(version) do
+    version 
+    |> String.split("+")
+    |> hd
+    |> String.split([".", "-"]) 
+    |> normalize_version 
+    |> Enum.join(".")
+  end
+  def normalize_version(v = [_maj, _min, _patch]) do
+    v
+  end
+  def normalize_version(v = [maj, _min, _patch, _pre]) when is_binary(maj) do
+    normalize_version(v |> Enum.map(fn(segment) -> Regex.replace(~r/[^0-9]+/, segment, "") |> String.to_integer end))
+  end
+  def normalize_version([maj, 0, 0, pre]) when maj > 0 do
+    [maj - 1, 99, 99, 99, pre]
+  end
+  def normalize_version([maj, min, 0, pre]) when min > 0 do
+    [maj, min - 1, 99, 99, pre]
+  end
+  def normalize_version([maj, min, patch, pre]) when patch > 0 do
+    [maj, min, patch - 1, 99, pre]
+  end
+end

--- a/lib/exrm_rpm/normalize_version.ex
+++ b/lib/exrm_rpm/normalize_version.ex
@@ -22,4 +22,11 @@ defmodule ReleaseManager.Plugin.Rpm.NormalizeVersion do
   def normalize_version([maj, min, patch, pre]) when patch > 0 do
     [maj, min, patch - 1, 99, pre]
   end
+
+  def build_number(version) when is_binary(version) do
+    case version |> String.split("+") do
+      [ver, build] -> build
+      _ -> "0"
+    end
+  end
 end

--- a/test/exrm_rpm_test.exs
+++ b/test/exrm_rpm_test.exs
@@ -15,6 +15,16 @@ defmodule ExrmRpmTest do
     IO.puts rpm_file
   end
 
+  test "rpm_file_name with build", %{config: config} do
+    rpm_file = Rpm.rpm_file_name("test", "0.0.1+47", "x86_64")
+    assert rpm_file == "test-0.0.1-47.x86_64.rpm"
+  end
+
+  test "rpm_file_name without build", %{config: config} do
+    rpm_file = Rpm.rpm_file_name("test", "0.0.1", "x86_64")
+    assert rpm_file == "test-0.0.1-0.x86_64.rpm"
+  end
+
   test "creates the spec work directories", meta do
     Rpm.after_release(meta[:config])
   end

--- a/test/normalize_version_test.exs
+++ b/test/normalize_version_test.exs
@@ -1,0 +1,22 @@
+defmodule NormalizeVersionTest do
+  use ExUnit.Case
+  alias ReleaseManager.Config
+  alias ReleaseManager.Plugin.Rpm
+  
+  import ReleaseManager.Plugin.Rpm.NormalizeVersion
+
+  test "normalize_version acts correctly" do
+    versions = %{
+        "1.2.3" => "1.2.3",
+        "1.0.0-alpha1" => "0.99.99.99.1",
+        "1.1.0-alpha1" => "1.0.99.99.1",
+        "1.1.1-alpha1" => "1.1.0.99.1",
+        "1.2.3+60" => "1.2.3",
+        "1.2.3-alpha1+60" => "1.2.2.99.1"
+      }
+
+    for {version, expected} <- versions do
+      assert expected == normalize_version(version)
+    end
+  end
+end

--- a/test/normalize_version_test.exs
+++ b/test/normalize_version_test.exs
@@ -16,7 +16,20 @@ defmodule NormalizeVersionTest do
       }
 
     for {version, expected} <- versions do
-      assert expected == normalize_version(version)
+      assert normalize_version(version) == expected
+    end
+  end
+
+  test "build_number acts correctly" do
+    versions = %{
+      "1.2.3" => "0",
+      "1.0.0-alpha1" => "0",
+      "1.2.3+60" => "60",
+      "1.2.3-alpha1+60" => "60"
+    }
+
+    for {version, expected} <- versions do
+      assert build_number(version) == expected
     end
   end
 end


### PR DESCRIPTION

[Semantic version](https://semver.org/) has pre-version and build parts, separated by "-" and "+". Take build part, and put it in rpm filename. 
Version 0.0.1+47 outputs file test-0.0.1-47.x86_64.rpm
